### PR TITLE
use http_proxy environment variable to start Net:HTTP

### DIFF
--- a/lib/kindai/util.rb
+++ b/lib/kindai/util.rb
@@ -121,7 +121,10 @@ module Kindai::Util
     self.logger.debug "get_redirected_uri #{uri}"
 
     response = nil
-    Net::HTTP.start(uri.host, uri.port) {|http|
+    proxy_uri = URI.parse(ENV["http_proxy"] || ENV["HTTP_PROXY"] || "")
+    proxy_user, proxy_pass = proxy.userinfo.split(/:/) if proxy_uri.userinfo
+    Net::HTTP.Proxy(proxy_uri.host, proxy_uri.port,
+                    proxy_user, proxy_pass).start(uri.host, uri.port) {|http|
       response = http.head(uri.request_uri)
     }
     response['Location']

--- a/lib/kindai/util/database.rb
+++ b/lib/kindai/util/database.rb
@@ -60,7 +60,10 @@ module Kindai::Util::Database
     }
     self.validate(send_data)
 
-    res = Net::HTTP.start(ENDPOINT.host, ENDPOINT.port){|http|
+    proxy_uri = URI.parse(ENV["http_proxy"] || ENV["HTTP_PROXY"] || "")
+    proxy_user, proxy_pass = proxy.userinfo.split(/:/) if proxy_uri.userinfo
+    res = Net::HTTP.Proxy(proxy_uri.host, proxy_uri.port,
+                          proxy_user, proxy_pass).start(ENDPOINT.host, ENDPOINT.port){|http|
       request = Net::HTTP::Post.new(ENDPOINT.path)
       request.set_form_data({:value => send_data.to_json, :group => book.key})
       http.request(request)


### PR DESCRIPTION
環境変数 http_proxy または HTTP_PROXY が "http://user:pass@proxy.example.com:8080/" のように設定されている場合に、それらを利用して接続できるよう変更しました。
