### PR TITLE
creatorがない場合publisherでもいいようにする

### DIFF
--- a/lib/kindai/book.rb
+++ b/lib/kindai/book.rb
@@ -50,7 +50,13 @@ module Kindai
     def author
       metadata_like 'creator:NDLNH'
     rescue
+      alt_author
+    end
+    
+    def alt_author
       metadata_like 'creator'
+    rescue
+      metadata_like 'publisher'
     end
 
     def total_spread


### PR DESCRIPTION
メタデータにcreator:NDLNH, creatorともに欠落している資料があるみたいです。
例: http://kindai.ndl.go.jp/info:ndljp/pid/843956

これをDLしようとするとランタイムエラーが起きてしまいます。
対策としてlib/book.rbでcreator:NDLNHがない場合にcreatorすらないならpublisherを使うよう変更をしてみました。

creator:NDLNHに出版社名を使っている資料もあるようなので、これでもいいのではないかなと思っていますがどうでしょうか。
例: http://kindai.ndl.go.jp/info:ndljp/pid/1168875
